### PR TITLE
Adds handling for case when the regex pattern can't identify a match

### DIFF
--- a/erddap_metrics/lib/erddap_metrics.py
+++ b/erddap_metrics/lib/erddap_metrics.py
@@ -147,7 +147,7 @@ class ErddapMetrics(metaclass=Singleton):
         if num_total_datasets > 0:
             _m('erddap_server_num_failed_load_datasets',
                'Total number of table datasets that failed to load (n Datasets Failed To Load)',
-               _first_result(r"n Datasets Failed To Load \(in the last major LoadDatasets\) = (\d+)", 0))
+               _first_result(r"n Datasets Failed To Load \(in the last major LoadDatasets\) = (\d+)", -1))
 
             _m('erddap_server_num_recent_success_responses', 'Number of successful responses since last Daily Report',
                _first_result(r"Response Succeeded Time \(since last Daily Report\)\s+n =\s+(\d+)"))


### PR DESCRIPTION
This commit updates a closure responsible for translating the match for a pattern in the status page to a metric so that a default value can be provided if no match is found.

If there are no failed datasets, the closure would raise an Exception. Now, the closure is provided a default value of 0, so that if there are no failed datasets, the metric produced is reported as 0.